### PR TITLE
Fixes for interaction with fader

### DIFF
--- a/src/apps/Partyman/PlayerFSMLoading.cpp
+++ b/src/apps/Partyman/PlayerFSMLoading.cpp
@@ -41,6 +41,9 @@ bool PlayerFSMLoading::enter()
    mInScan = false;
    QString fileName( mpPlayerWidget->mpScrollLine->toolTip() );
 
+// ThOr: always rescan, dermixd could be started with options (input.zerscan)
+// that modify the length of tracks
+#if 0
 #if 0
    mpPlayerWidget->mpDatabase->getTrackInfo( &(mpPlayerWidget->mTrackInfo), fileName );
 #endif
@@ -57,6 +60,7 @@ bool PlayerFSMLoading::enter()
       }
    }
    else
+#endif
    {
       needRescan = true;
    }

--- a/src/apps/Partyman/PlayerFSMPlaying.cpp
+++ b/src/apps/Partyman/PlayerFSMPlaying.cpp
@@ -33,7 +33,8 @@ bool PlayerFSMPlaying::enter()
 {
    mpPlayerWidget->mpStatusDisplay->setText( QWidget::tr("playing") );
    mpPlayerWidget->sendCommand( "start" );
-   mpPlayerWidget->sendCommand( "seek", QString::number(mpPlayerWidget->mpPlayPosition->value()) );
+// ThOr: Why seeking again here, already seeked on moving the slider?
+//   mpPlayerWidget->sendCommand( "seek", QString::number(mpPlayerWidget->mpPlayPosition->value()) );
    mpPlayerWidget->mpControlWidget->log( "p0p", "play", mpPlayerWidget->mpScrollLine->toolTip() );
    mpPlayerWidget->sendCommand( "watch" );
    mpPlayerWidget->disablePlayPosition( mpPlayerWidget->mKioskMode );

--- a/src/apps/Partyman/PlayerWidget.cpp
+++ b/src/apps/Partyman/PlayerWidget.cpp
@@ -11,6 +11,7 @@
 
 /* system headers */
 #include <iostream>
+#include <cmath>
 
 /* Qt headers */
 #include <QBoxLayout>
@@ -535,6 +536,10 @@ void PlayerWidget::handleScan( const QString &data )
    updateTime();
 }
 
+static double to_db(double factor)
+{
+	return factor > 2.5e-10 ? std::log(factor)/std::log(10)*20 : -192;
+}
 
 bool PlayerWidget::setVolume()
 {
@@ -551,13 +556,13 @@ bool PlayerWidget::setVolume()
       if( mTrackInfo.isFlagged( TrackInfo::ScannedWithPower ) )
       {
          adjust = mNormalizeValue / mTrackInfo.mVolume;
-         sendCommand( "volume", QString::number(adjust) );
+         sendCommand( "preamp", QString::number(to_db(adjust)) );
          return true;
       }
       if( mTrackInfo.isFlagged( TrackInfo::ScannedWithPeak ) )
       {
          adjust = 1.0 / mTrackInfo.mVolume;
-         sendCommand( "volume", QString::number(adjust) );
+         sendCommand( "preamp", QString::number(to_db(adjust)) );
          return true;
       }
    }


### PR DESCRIPTION
Here are three changes for review/inclusion.

1. Use preamp instead of volume for relative volume adjustment / normalization.
2. Always re-scan track on loading to be prepared for DerMixD features that modify track runtime.
3. Remove a superfluous seek (?).

The first one leaves the volume factors free to play with while fading with external client script, not having to try and preserve the relative volume. That is what preamp is for. The re-scanning seems necessary for me, not totally sure. I tried debugging issues with input.zeroscan in dermixd and stumbled upon this. But this did not fix it, while it still seems to be relevant.

Then the extra seek seemed unncecessary and I am not totally sure anymore, but I think it helped some perceived stutter.